### PR TITLE
chakra ui → shadcn/ui 移行

### DIFF
--- a/src/app/edit/_components/ColorStyle.tsx
+++ b/src/app/edit/_components/ColorStyle.tsx
@@ -1,12 +1,8 @@
 "use client";
 
-import { ThemeColors } from "@/types";
-import { useTheme } from "@chakra-ui/react";
 import dynamic from "next/dynamic";
 
 const ColorStyle = () => {
-  const theme: ThemeColors = useTheme();
-
   return (
     <style id="color_style">{`
         #time-range {
@@ -17,7 +13,7 @@ const ColorStyle = () => {
   outline: none;
   border-radius: 15px;
    height: 6px;
-  background: ${theme.colors.text.body}30;
+  background: hsl(var(--foreground) / 0.3);
 }
 
 /* Thumb: webkit */
@@ -28,7 +24,7 @@ const ColorStyle = () => {
   /* creating a custom design */
   height: 15px;
   width: 15px;
-  background-color: ${theme.colors.primary.main};
+  background-color: hsl(var(--primary));
   border-radius: 50%;
   border: none;
 
@@ -39,7 +35,7 @@ const ColorStyle = () => {
 #time-range::-moz-range-thumb {
   height: 15px;
   width: 15px;
-  background-color: ${theme.colors.primary.main};
+  background-color: hsl(var(--primary));
   border-radius: 50%;
   border: none;
   transition: .2s ease-in-out;
@@ -48,25 +44,25 @@ const ColorStyle = () => {
 /* Hover, active & focus Thumb: Webkit */
 
 #time-range::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 0 10px ${theme.colors.primary.main}40
+  box-shadow: 0 0 0 10px hsl(var(--primary) / 0.4)
 }
 #time-range:active::-webkit-slider-thumb {
-  box-shadow: 0 0 0 13px ${theme.colors.primary.main}60
+  box-shadow: 0 0 0 13px hsl(var(--primary) / 0.6)
 }
 #time-range:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 13px ${theme.colors.primary.main}60
+  box-shadow: 0 0 0 13px hsl(var(--primary) / 0.6)
 }
 
 /* Hover, active & focus Thumb: Firfox */
 
 #time-range::-moz-range-thumb:hover {
-  box-shadow: 0 0 0 10px ${theme.colors.primary.main}40
+  box-shadow: 0 0 0 10px hsl(var(--primary) / 0.4)
 }
 #time-range:active::-moz-range-thumb {
-  box-shadow: 0 0 0 13px ${theme.colors.primary.main}60
+  box-shadow: 0 0 0 13px hsl(var(--primary) / 0.6)
 }
 #time-range:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 13px ${theme.colors.primary.main}60
+  box-shadow: 0 0 0 13px hsl(var(--primary) / 0.6)
 }
 
       `}</style>

--- a/src/app/edit/_components/Content.tsx
+++ b/src/app/edit/_components/Content.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { Box, Flex, Grid, useToast } from "@chakra-ui/react";
 import { useEffect } from "react";
 import LoadingOverlayWrapper from "react-loading-overlay-ts";
+import { toast } from "sonner";
 import { usePathChangeAtomReset } from "../atoms/reset";
 import { useCanUploadState, useIsLrcConvertingState } from "../atoms/stateAtoms";
 import { useTimerRegistration } from "../hooks/useTimer";
@@ -17,7 +17,6 @@ function Content() {
 
   const { addTimer, removeTimer } = useTimerRegistration();
   const pathChangeReset = usePathChangeAtomReset();
-  const chakraToast = useToast();
   const canUpload = useCanUploadState();
   const hasUploadPermission = useHasMapUploadPermission();
 
@@ -26,7 +25,7 @@ function Content() {
     return () => {
       removeTimer();
       pathChangeReset();
-      chakraToast.close(NOT_EDIT_PERMISSION_TOAST_ID);
+      toast.dismiss(NOT_EDIT_PERMISSION_TOAST_ID);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -55,18 +54,18 @@ function Content() {
       text="Loading..."
       className="w-full xl:w-[90%] 2xl:w-[80%]"
     >
-      <Box marginX={{ base: 0, md: "auto" }} pt={{ base: 4, lg: 0 }}>
-        <Flex as="section" flexDirection={{ base: "column", lg: "row" }} width="100%" gap={{ base: 2, lg: 6 }}>
+      <div className="mx-0 md:mx-auto pt-4 lg:pt-0">
+        <section className="flex flex-col lg:flex-row w-full gap-2 lg:gap-6">
           <EditYouTube className="aspect-video h-[286px] w-full select-none lg:w-[416px]" />
           <EditorTabContent />
-        </Flex>
-        <Grid as="section" width="100%" my={1} gridTemplateColumns="1fr auto" gap-y="1px" alignItems="center">
+        </section>
+        <section className="grid w-full my-1 grid-cols-[1fr_auto] gap-y-[1px] items-center">
           <TimeRange />
-        </Grid>
-        <Box as="section" width="100%">
+        </section>
+        <section className="w-full">
           <EditTable />
-        </Box>
-      </Box>
+        </section>
+      </div>
     </LoadingOverlayWrapper>
   );
 }

--- a/src/app/edit/_components/map-table/EditTable.tsx
+++ b/src/app/edit/_components/map-table/EditTable.tsx
@@ -1,9 +1,9 @@
 "use client";
 /* eslint-disable react-hooks/exhaustive-deps */
-import { Card, Table, TableContainer, Tbody, Th, Thead, Tr, useTheme } from "@chakra-ui/react";
+import { Card } from "@/components/ui/card";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 import "@/app/edit/style/table.scss";
-import { ThemeColors } from "@/types";
 import { useMapQueries } from "@/utils/queries/map.queries";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
@@ -15,7 +15,6 @@ import { useIsYTReadiedState, useIsYTStartedState } from "../../atoms/stateAtoms
 import MapTableBody from "./child/MapTableBody";
 
 export default function EditTable() {
-  const theme: ThemeColors = useTheme();
   const tbodyRef = useRef(null);
   const { writeTbody } = useTbody();
 
@@ -73,39 +72,31 @@ export default function EditTable() {
   }, [isYTReady, isYTStarted]);
 
   return (
-    <Card bg={theme.colors.background.card} color={theme.colors.text.body} m={2}>
+    <Card className="bg-card text-foreground m-2">
       <LoadingOverlayWrapper active={isLoading} spinner={true} text="Loading...">
-        <TableContainer
-          maxH={{ sm: "calc(100vh - 100px)", md: "500px", "2xl": "calc(100vh - 400px)" }}
-          overflowY="auto"
-        >
-          <Table size="sm" variant="simple" mb={{ sm: "65vh", md: "60vh", "2xl": "30vh" }}>
-            <Thead>
-              <Tr>
-                <Th width="5%" borderRight="1px solid" borderRightColor={`${theme.colors.border.editorTable.right}`}>
+        <div className="max-h-[calc(100vh-100px)] md:max-h-[500px] 2xl:max-h-[calc(100vh-400px)] overflow-y-auto">
+          <Table className="text-sm mb-[65vh] md:mb-[60vh] 2xl:mb-[30vh]">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[5%] border-r border-border">
                   Time
-                </Th>
-                <Th borderRight="1px solid" borderRightColor={`${theme.colors.border.editorTable.right}`}>
+                </TableHead>
+                <TableHead className="border-r border-border">
                   歌詞
-                </Th>
-                <Th borderRight="1px solid" borderRightColor={`${theme.colors.border.editorTable.right}`}>
+                </TableHead>
+                <TableHead className="border-r border-border">
                   ワード
-                </Th>
-                <Th
-                  width="3%"
-                  textAlign="center"
-                  borderRight="1px solid"
-                  borderRightColor={`${theme.colors.border.editorTable.right}`}
-                >
+                </TableHead>
+                <TableHead className="w-[3%] text-center border-r border-border">
                   オプション
-                </Th>
-              </Tr>
-            </Thead>
-            <Tbody ref={tbodyRef}>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody ref={tbodyRef}>
               <MapTableBody />
-            </Tbody>
+            </TableBody>
           </Table>
-        </TableContainer>
+        </div>
       </LoadingOverlayWrapper>
     </Card>
   );

--- a/src/app/edit/_components/map-table/child/LineOptionModal.tsx
+++ b/src/app/edit/_components/map-table/child/LineOptionModal.tsx
@@ -1,23 +1,10 @@
 "use client";
 
-import { ThemeColors } from "@/types";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { MapLineEdit } from "@/types/map";
-import {
-  Badge,
-  Box,
-  Checkbox,
-  FormLabel,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Stack,
-  useDisclosure,
-  useTheme,
-} from "@chakra-ui/react";
 import { Dispatch, useState } from "react";
 import ChangeLineVideoSpeedOption from "./line-option-child/ChangeLineVideoSpeedOption";
 import CSSInput from "./line-option-child/CSSInput";
@@ -45,100 +32,102 @@ export default function LineOptionModal({
   const [isEditedCSS, setIsEditedCSS] = useState(false);
   const [changeVideoSpeed, setChangeVideoSpeed] = useState(0);
   const [isChangeCSS, setIsEditChangeCSS] = useState(lineOptions?.isChangeCSS || false);
-  const confirmModal = useDisclosure();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
-  const theme: ThemeColors = useTheme();
   const handleModalClose = () => {
     if (isEditedCSS) {
-      confirmModal.onOpen();
+      setIsConfirmOpen(true);
     } else {
       onClose();
       setOptionModalIndex(null);
     }
   };
   return (
-    <Modal isOpen={isOpen} isCentered onClose={handleModalClose} closeOnOverlayClick={false}>
-      <ModalOverlay />
-      <ModalContent maxW="600px" bg={theme.colors.background.card} color={theme.colors.text.body}>
-        <ModalHeader>ラインオプション </ModalHeader>
+    <>
+      <Dialog open={isOpen} onOpenChange={handleModalClose}>
+        <DialogContent className="max-w-[600px] bg-card text-foreground">
+          <DialogHeader>
+            <DialogTitle>ラインオプション</DialogTitle>
+          </DialogHeader>
+          
+          <div className="space-y-4">
+            <Badge variant="secondary" className="text-base">
+              選択ライン: {optionModalIndex}
+            </Badge>
 
-        <ModalCloseButton onClick={handleModalClose} />
-        <ModalBody>
-          <Badge colorScheme="teal" fontSize="1em" mb={2}>
-            選択ライン: {optionModalIndex}
-          </Badge>
+            <div className="space-y-2">
+              <ChangeLineVideoSpeedOption
+                changeVideoSpeed={changeVideoSpeed}
+                setChangeVideoSpeed={setChangeVideoSpeed}
+              />
+              {optionModalIndex === 0 && (
+                <div>
+                  <Label>
+                    永続的に適用するCSSを入力
+                    <CSSInput
+                      disabled={false}
+                      CSSText={eternalCSS}
+                      setCSSText={setEternalCSS}
+                      setIsEditedCSS={setIsEditedCSS}
+                    />
+                  </Label>
+                  <CSSTextLength
+                    eternalCSSText={eternalCSS}
+                    changeCSSText={changeCSS}
+                    lineOptions={lineOptions}
+                  />
+                </div>
+              )}
 
-          <Stack spacing={2}>
-            <ChangeLineVideoSpeedOption
-              changeVideoSpeed={changeVideoSpeed}
-              setChangeVideoSpeed={setChangeVideoSpeed}
-            />
-            {optionModalIndex === 0 && (
-              <Box>
-                <FormLabel>
-                  永続的に適用するCSSを入力
+              <div>
+                <Label className="flex items-baseline">
+                  <Checkbox
+                    checked={isChangeCSS}
+                    onCheckedChange={(checked) => setIsEditChangeCSS(checked as boolean)}
+                    className="mr-1"
+                  />
+                  ライン切り替えを有効化
+                </Label>
+                <Label>
+                  選択ラインから適用するCSSを入力
                   <CSSInput
-                    disabled={false}
-                    CSSText={eternalCSS}
-                    setCSSText={setEternalCSS}
+                    disabled={!isChangeCSS}
+                    CSSText={changeCSS}
+                    setCSSText={setChangeCSS}
                     setIsEditedCSS={setIsEditedCSS}
                   />
-                </FormLabel>
+                </Label>
                 <CSSTextLength
                   eternalCSSText={eternalCSS}
                   changeCSSText={changeCSS}
                   lineOptions={lineOptions}
                 />
-              </Box>
-            )}
+              </div>
 
-            <Box>
-              <FormLabel display="flex" alignItems="baseline">
-                <Checkbox
-                  isChecked={isChangeCSS}
-                  onChange={(event) => setIsEditChangeCSS(event.target.checked)}
-                  mr={1}
-                />
-                ライン切り替えを有効化
-              </FormLabel>
-              <FormLabel>
-                選択ラインから適用するCSSを入力
-                <CSSInput
-                  disabled={!isChangeCSS}
-                  CSSText={changeCSS}
-                  setCSSText={setChangeCSS}
-                  setIsEditedCSS={setIsEditedCSS}
-                />
-              </FormLabel>
-              <CSSTextLength
-                eternalCSSText={eternalCSS}
-                changeCSSText={changeCSS}
-                lineOptions={lineOptions}
+              <SaveOptionButton
+                eternalCSS={eternalCSS}
+                changeCSS={changeCSS}
+                isEditedCSS={isEditedCSS}
+                isChangeCSS={isChangeCSS}
+                optionModalIndex={optionModalIndex}
+                setOptionModalIndex={setOptionModalIndex}
+                onClose={onClose}
+                setIsEditedCSS={setIsEditedCSS}
+                changeVideoSpeed={changeVideoSpeed}
               />
-            </Box>
+            </div>
+          </div>
 
-            <SaveOptionButton
-              eternalCSS={eternalCSS}
-              changeCSS={changeCSS}
-              isEditedCSS={isEditedCSS}
-              isChangeCSS={isChangeCSS}
-              optionModalIndex={optionModalIndex}
-              setOptionModalIndex={setOptionModalIndex}
-              onClose={onClose}
-              setIsEditedCSS={setIsEditedCSS}
-              changeVideoSpeed={changeVideoSpeed}
-            />
-          </Stack>
-        </ModalBody>
-
-        <ModalFooter></ModalFooter>
-      </ModalContent>
+          <DialogFooter />
+        </DialogContent>
+      </Dialog>
+      
       <LineOptionModalCloseButton
         onClose={onClose}
-        isConfirmOpen={confirmModal.isOpen}
-        onConfirmClose={confirmModal.onClose}
+        isConfirmOpen={isConfirmOpen}
+        onConfirmClose={() => setIsConfirmOpen(false)}
         setOptionModalIndex={setOptionModalIndex}
       />
-    </Modal>
+    </>
   );
 }

--- a/src/app/edit/_components/tab/TabList.tsx
+++ b/src/app/edit/_components/tab/TabList.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { ThemeColors } from "@/types";
-import { Tab, TabList, TabPanel, TabPanels, Tabs, useTheme } from "@chakra-ui/react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSetTabIndex, useTabIndexState } from "../../atoms/stateAtoms";
 import { TabIndex } from "../../ts/type";
 import TabEditor from "./tab-panels/TabEditor";
@@ -12,50 +11,43 @@ interface EditorTabContentProps {
 }
 
 const TAB_LIST = ["情報 & 保存", "エディター", "設定 & ショートカットキー"];
+const TAB_VALUES = ["info", "editor", "settings"] as const;
+
 export default function EditorTabContent({ className }: EditorTabContentProps) {
   const tabIndex = useTabIndexState();
   const setTabIndex = useSetTabIndex();
-  const theme: ThemeColors = useTheme();
 
   return (
     <Tabs
-      index={tabIndex}
-      onChange={(index) => setTabIndex(index as TabIndex)}
-      className={className}
-      isFitted
-      size="sm"
-      position="relative"
-      variant="line"
-      width="100%"
+      value={TAB_VALUES[tabIndex]}
+      onValueChange={(value) => setTabIndex(TAB_VALUES.indexOf(value as typeof TAB_VALUES[number]) as TabIndex)}
+      className={`w-full ${className || ""}`}
     >
-      <TabList height="25px" px={{ base: "0", md: "8" }} borderBottom={`1px solid ${theme.colors.text.body}aa`}>
+      <TabsList className="h-[25px] w-full grid grid-cols-3 px-0 md:px-8 border-b border-foreground/60">
         {TAB_LIST.map((tabName, index) => {
           return (
-            <Tab
+            <TabsTrigger
               key={index}
-              opacity={tabIndex === index ? 1 : 0.5}
-              color={theme.colors.text.body}
-              _hover={{ bg: theme.colors.button.sub.hover, opacity: 0.8 }}
-              isTruncated
+              value={TAB_VALUES[index]}
+              className={`truncate ${tabIndex === index ? "opacity-100" : "opacity-50"} hover:bg-secondary hover:opacity-80`}
             >
               {tabName}
-            </Tab>
+            </TabsTrigger>
           );
         })}
-      </TabList>
+      </TabsList>
 
-      <TabPanels>
-        <TabPanel px={0} pb={0} pt={2}>
-          <TabInfoUpload />
-        </TabPanel>
+      <TabsContent value="info" className="px-0 pb-0 pt-2">
+        <TabInfoUpload />
+      </TabsContent>
 
-        <TabPanel px={0} pb={0} pt={2}>
-          <TabEditor />
-        </TabPanel>
-        <TabPanel px={0} pb={0} pt={2}>
-          <TabSettings />
-        </TabPanel>
-      </TabPanels>
+      <TabsContent value="editor" className="px-0 pb-0 pt-2">
+        <TabEditor />
+      </TabsContent>
+      
+      <TabsContent value="settings" className="px-0 pb-0 pt-2">
+        <TabSettings />
+      </TabsContent>
     </Tabs>
   );
 }

--- a/src/app/edit/_components/tab/tab-panels/TabEditor.tsx
+++ b/src/app/edit/_components/tab/tab-panels/TabEditor.tsx
@@ -1,5 +1,4 @@
-import { ThemeColors } from "@/types";
-import { Card, CardBody, Flex, Stack, useTheme } from "@chakra-ui/react";
+import { Card, CardContent } from "@/components/ui/card";
 
 import EditorButtons from "./tab-editor-child/EditorButtons";
 import EditorLineInput from "./tab-editor-child/EditorInputs";
@@ -7,21 +6,19 @@ import ManyPhraseTextarea from "./tab-editor-child/ManyPhraseTextarea";
 import AddTimeAdjust from "./tab-settings-shortcutlist-child/settings-child/AddTimeAdjust";
 
 const TabEditor = () => {
-  const theme: ThemeColors = useTheme();
-
   return (
-    <Card variant="filled" bg={theme.colors.background.card} boxShadow="lg" color={theme.colors.text.body}>
-      <CardBody py={4}>
-        <Stack display="flex" flexDirection="column" gap={1}>
+    <Card className="bg-card shadow-lg text-foreground">
+      <CardContent className="py-4">
+        <div className="flex flex-col gap-1">
           <EditorLineInput />
 
-          <Flex justifyContent="space-between" alignItems="center">
+          <div className="flex justify-between items-center">
             <EditorButtons />
             <AddTimeAdjust />
-          </Flex>
+          </div>
           <ManyPhraseTextarea />
-        </Stack>
-      </CardBody>
+        </div>
+      </CardContent>
     </Card>
   );
 };

--- a/src/app/edit/_components/tab/tab-panels/TabInfoUpload.tsx
+++ b/src/app/edit/_components/tab/tab-panels/TabInfoUpload.tsx
@@ -1,10 +1,10 @@
-import { Card, CardBody, Flex, HStack, Stack, useTheme, useToast } from "@chakra-ui/react";
+import { Card, CardContent } from "@/components/ui/card";
+import { toast } from "sonner";
 
 import { useSetGeminiTags, useSetMapInfo, useVideoIdState } from "@/app/edit/atoms/stateAtoms";
 import useHasMapUploadPermission from "@/app/edit/hooks/useUserEditPermission";
 import { useUploadMap } from "@/app/edit/hooks/utils/useUploadMap";
 import { INITIAL_SERVER_ACTIONS_STATE } from "@/app/edit/ts/const/editDefaultValues";
-import { ThemeColors } from "@/types";
 import { useCustomToast } from "@/utils/global-hooks/useCustomToast";
 import { useGeminiQueries } from "@/utils/queries/gemini.queries";
 import { useQuery } from "@tanstack/react-query";
@@ -19,8 +19,7 @@ import UploadButton from "./tab-info-child/UploadButton";
 export const NOT_EDIT_PERMISSION_TOAST_ID = "not-edit-permission-toast";
 
 const TabInfoUpload = () => {
-  const toast = useCustomToast();
-  const theme: ThemeColors = useTheme();
+  const customToast = useCustomToast();
   const searchParams = useSearchParams();
   const isNewCreate = !!searchParams.get("new");
   const videoId = useVideoIdState();
@@ -32,16 +31,15 @@ const TabInfoUpload = () => {
     isFetching,
     error,
   } = useQuery(useGeminiQueries().generateMapInfo({ videoId }, { enabled: !isBackUp && hasUploadPermission }));
-  const chakraToast = useToast();
 
   const setGeminiTags = useSetGeminiTags();
   const setMapInfo = useSetMapInfo();
 
   useEffect(() => {
     if (error) {
-      toast({ type: "error", title: error.message });
+      customToast({ type: "error", title: error.message });
     }
-  }, [error, toast]);
+  }, [error, customToast]);
 
   useEffect(() => {
     if (mapInfoData) {
@@ -62,47 +60,37 @@ const TabInfoUpload = () => {
 
   useEffect(() => {
     if (!hasUploadPermission) {
-      const existingToast = chakraToast.isActive(NOT_EDIT_PERMISSION_TOAST_ID);
-      if (!existingToast) {
-        toast({
-          type: "warning",
-          title: "編集保存権限がないため譜面の更新はできません",
-          duration: null,
-          size: "sm",
-          isClosable: false,
-          id: NOT_EDIT_PERMISSION_TOAST_ID,
-        });
-      } else {
-        chakraToast.close(NOT_EDIT_PERMISSION_TOAST_ID);
-      }
+      toast.warning("編集保存権限がないため譜面の更新はできません", {
+        id: NOT_EDIT_PERMISSION_TOAST_ID,
+        duration: Infinity,
+      });
+    } else {
+      toast.dismiss(NOT_EDIT_PERMISSION_TOAST_ID);
     }
-  }, [chakraToast, hasUploadPermission, toast]);
+  }, [hasUploadPermission]);
 
   return (
-    <Card variant="filled" bg={theme.colors.background.card} boxShadow="lg" color={theme.colors.text.body}>
-      <CardBody>
-        <Stack display="flex" flexDirection="column" gap="6">
+    <Card className="bg-card shadow-lg text-foreground">
+      <CardContent className="p-6">
+        <div className="flex flex-col gap-6">
           <InfoInputForm isGeminiLoading={isFetching && isNewCreate} />
           <InfoTag isGeminiLoading={isFetching} />
-          <HStack justifyContent="space-between">
+          <div className="flex justify-between">
             {hasUploadPermission ? (
-              <Flex
-                as={"form"}
+              <form
                 action={formAction}
-                gap={4}
-                alignItems="baseline"
-                flexDirection={{ base: "column", lg: "row" }}
+                className="flex gap-4 items-baseline flex-col lg:flex-row"
               >
                 <UploadButton state={state} />
                 {mapId ? <TypeLinkButton /> : ""}
-              </Flex>
+              </form>
             ) : (
               mapId && <TypeLinkButton />
             )}
             <PreviewTimeInput />
-          </HStack>
-        </Stack>
-      </CardBody>
+          </div>
+        </div>
+      </CardContent>
     </Card>
   );
 };

--- a/src/app/edit/_components/tab/tab-panels/TabSettingsShortcutList.tsx
+++ b/src/app/edit/_components/tab/tab-panels/TabSettingsShortcutList.tsx
@@ -1,19 +1,16 @@
-import { ThemeColors } from "@/types";
-import { Card, CardBody, Stack, useTheme } from "@chakra-ui/react";
+import { Card, CardContent } from "@/components/ui/card";
 import EditorSettingModal from "./tab-settings-shortcutlist-child/Settings";
 import ShortCutKeyList from "./tab-settings-shortcutlist-child/settings-child/ShortCutKeyList";
 
 const TabSettings = () => {
-  const theme: ThemeColors = useTheme();
-
   return (
-    <Card bg={theme.colors.background.card}>
-      <CardBody>
-        <Stack spacing={6}>
+    <Card className="bg-card">
+      <CardContent className="p-6">
+        <div className="space-y-6">
           <EditorSettingModal />
           <ShortCutKeyList />
-        </Stack>
-      </CardBody>
+        </div>
+      </CardContent>
     </Card>
   );
 };

--- a/src/app/edit/_components/tab/tab-panels/tab-info-child/TypeLinkButton.tsx
+++ b/src/app/edit/_components/tab/tab-panels/tab-info-child/TypeLinkButton.tsx
@@ -1,23 +1,17 @@
-import { ThemeColors } from "@/types";
+import { Button } from "@/components/ui/button";
 import { useLinkClick } from "@/utils/global-hooks/useLinkClick";
-import { Link } from "@chakra-ui/next-js";
-import { Button, useTheme } from "@chakra-ui/react";
+import Link from "next/link";
 import { useParams } from "next/navigation";
 
 const TypeLinkButton = () => {
-  const theme: ThemeColors = useTheme();
   const { id } = useParams();
   const handleLinkClick = useLinkClick();
   return (
     <Link href={`/type/${id}`} onClick={handleLinkClick}>
       <Button
-        size="md"
+        size="default"
         variant="outline"
-        color={theme.colors.text.body}
-        borderColor={theme.colors.border.card}
-        _hover={{
-          bg: theme.colors.button.sub.hover,
-        }}
+        className="text-foreground border-border hover:bg-secondary"
       >
         タイピングページに移動
       </Button>

--- a/src/app/edit/_components/tab/tab-panels/tab-info-child/UploadButton.tsx
+++ b/src/app/edit/_components/tab/tab-panels/tab-info-child/UploadButton.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { Button, useTheme } from "@chakra-ui/react";
+import { Button } from "@/components/ui/button";
 
 import { useReadMap } from "@/app/edit/atoms/mapReducerAtom";
 import { useCanUploadState, useReadMapInfo, useReadMapTags, useSetCanUpload } from "@/app/edit/atoms/stateAtoms";
 import { useBackupNewMap, useDeleteBackupNewMap } from "@/lib/db";
 import { useTRPC } from "@/trpc/trpc";
-import { ThemeColors, UploadResult } from "@/types";
+import { UploadResult } from "@/types";
 import { useCustomToast } from "@/utils/global-hooks/useCustomToast";
 import { useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
@@ -17,7 +17,6 @@ interface UploadButtonProps {
 }
 const UploadButton = ({ state }: UploadButtonProps) => {
   const { pending } = useFormStatus();
-  const theme: ThemeColors = useTheme();
   const canUpload = useCanUploadState();
   const setCanUpload = useSetCanUpload();
   const toast = useCustomToast();
@@ -74,19 +73,10 @@ const UploadButton = ({ state }: UploadButtonProps) => {
 
   return (
     <Button
-      className="cursor-pointer"
-      variant="solid"
+      className={`w-[200px] border cursor-pointer ${canUpload ? "opacity-100 hover:opacity-90" : "opacity-70"}`}
+      variant="default"
       size="lg"
-      width="200px"
-      border="1px"
-      isLoading={pending}
-      bg={theme.colors.primary.main}
-      color={theme.colors.text.body}
-      _hover={{
-        bg: canUpload ? theme.colors.primary.light : theme.colors.primary.main,
-      }}
-      borderColor={theme.colors.border.card}
-      opacity={canUpload ? "1" : "0.7"}
+      disabled={pending}
       type="submit"
       onClick={(e) => {
         if (!canUpload) {
@@ -94,12 +84,9 @@ const UploadButton = ({ state }: UploadButtonProps) => {
         }
       }}
     >
-      保存
+      {pending ? "保存中..." : "保存"}
     </Button>
   );
 };
 
 export default UploadButton;
-function useUtils() {
-  throw new Error("Function not implemented.");
-}

--- a/src/app/edit/_components/time-range/TimeRange.tsx
+++ b/src/app/edit/_components/time-range/TimeRange.tsx
@@ -1,7 +1,5 @@
 "use client";
 import "@/app/edit/style/editor.scss";
-import { ThemeColors } from "@/types";
-import { useTheme } from "@chakra-ui/react";
 import React, { useCallback, useEffect, useRef } from "react";
 import { useIsYTReadiedState, useIsYTStartedState } from "../../atoms/stateAtoms";
 
@@ -11,7 +9,6 @@ import EditSpeedChange from "./child/SpeedChange";
 
 const TimeRange = () => {
   const rangeRef = useRef<HTMLInputElement>(null);
-  const theme: ThemeColors = useTheme();
   const isYTStarted = useIsYTStartedState();
   const isYTReady = useIsYTReadiedState();
   const { readPlayer } = usePlayer();
@@ -38,7 +35,7 @@ const TimeRange = () => {
     }
 
     const progress = (time / Number(e.target.max)) * 100;
-    e.target.style.background = `linear-gradient(to right, ${theme.colors.primary.main} ${progress}%, ${theme.colors.text.body}30 ${progress}%)`;
+    e.target.style.background = `linear-gradient(to right, hsl(var(--primary)) ${progress}%, hsl(var(--foreground) / 0.3) ${progress}%)`;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/app/edit/_components/time-range/child/SpeedChange.tsx
+++ b/src/app/edit/_components/time-range/child/SpeedChange.tsx
@@ -1,41 +1,47 @@
 "use client";
 import { useSpeedReducer, useYTSpeedState } from "@/app/edit/atoms/stateAtoms";
 import "@/app/edit/style/editor.scss";
-import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import { Button } from "@/components/ui/button";
 
 const EditSpeedChange = () => {
   const speed = useYTSpeedState(); //0.25 or 2.00 場合片方のボタンをdisabledにする
   const speedDispatch = useSpeedReducer();
 
   return (
-    <HStack justify="center" className="w-[170px]">
-      <Box>
-        <Button cursor="pointer" variant="unstyled" onClick={() => speedDispatch("down")}>
-          <Box className="relative">
-            -
-            <Text as="span" className="f-key">
-              F9
-            </Text>
-          </Box>
-        </Button>
-      </Box>
-      <Box>
-        <Text as="span" id="speed">
+    <div className="flex items-center justify-center gap-2 w-[170px]">
+      <Button 
+        variant="ghost" 
+        size="sm"
+        onClick={() => speedDispatch("down")}
+        className="p-1 h-auto"
+      >
+        <div className="relative">
+          -
+          <span className="f-key">
+            F9
+          </span>
+        </div>
+      </Button>
+      <div>
+        <span id="speed">
           {speed.toFixed(2)}
-        </Text>
+        </span>
         倍速
-      </Box>
-      <Box>
-        <Button variant="unstyled" cursor="pointer" onClick={() => speedDispatch("up")}>
-          <Box className="relative">
-            +
-            <Text as="span" className="f-key">
-              F10
-            </Text>
-          </Box>
-        </Button>
-      </Box>
-    </HStack>
+      </div>
+      <Button 
+        variant="ghost"
+        size="sm" 
+        onClick={() => speedDispatch("up")}
+        className="p-1 h-auto"
+      >
+        <div className="relative">
+          +
+          <span className="f-key">
+            F10
+          </span>
+        </div>
+      </Button>
+    </div>
   );
 };
 

--- a/src/app/edit/_components/youtube/EditYouTubePlayer.tsx
+++ b/src/app/edit/_components/youtube/EditYouTubePlayer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Box } from "@chakra-ui/react";
 import { useCallback } from "react";
 import YouTube from "react-youtube";
 import { useVideoIdState } from "../../atoms/stateAtoms";
@@ -46,23 +45,21 @@ const EditYouTube = function ({ className }: EditorYouTubeProps) {
   );
 
   return (
-    <Box>
-      <YouTube
-        className={className}
-        id="edit_youtube"
-        videoId={videoId}
-        opts={{
-          width: "100%",
-          height: "100%",
-          playerVars: { enablejsapi: 1 },
-        }}
-        onReady={onReady}
-        onPlay={onPlay}
-        onPause={onPause}
-        onEnd={onEndStop}
-        onStateChange={handleStateChange}
-      />
-    </Box>
+    <YouTube
+      className={className}
+      id="edit_youtube"
+      videoId={videoId}
+      opts={{
+        width: "100%",
+        height: "100%",
+        playerVars: { enablejsapi: 1 },
+      }}
+      onReady={onReady}
+      onPlay={onPlay}
+      onPause={onPause}
+      onEnd={onEndStop}
+      onStateChange={handleStateChange}
+    />
   );
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "@/styles/globals.css";
 import type { Metadata } from "next";
 
 import LinkLoader from "@/components/ui/link-loader";
+import { Toaster } from "@/components/ui/sonner";
 import { auth } from "@/server/auth";
 import TRPCProvider from "@/trpc/provider";
 import { serverApi } from "@/trpc/server";
@@ -52,6 +53,7 @@ export default async function RootLayout({
               </GlobalProvider>
             </TRPCProvider>
           </SessionProvider>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>


### PR DESCRIPTION
- Replace Chakra UI components with shadcn/ui equivalents
- Convert Box, Flex, Grid to semantic HTML with Tailwind
- Migrate toast system from Chakra to sonner
- Update theme colors to use CSS variables
- Maintain existing functionality with minimal logic changes